### PR TITLE
Transpile everything except es6 module syntax for jsnext:main build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,7 @@
 {
-  "presets": ["es2015", "react", "stage-2"]
+  "presets": [
+		["es2015", { "modules": false }],
+		"react",
+		"stage-2"
+	]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 coverage
 node_modules
 dist
+es6
 lib
 npm-debug.log
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -3,14 +3,15 @@
   "version": "1.0.1",
   "description": "A higher order component decorator to spy on Redux state with subscribing to it",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./es6/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/erikras/redux-spy"
   },
   "scripts": {
-    "build": "npm run build:lib && npm run build:umd && npm run build:umd:min",
-    "build:lib": "babel src --out-dir lib",
+    "build": "npm run build:es6 && npm run build:lib && npm run build:umd && npm run build:umd:min",
+    "build:es6": "babel src --out-dir es6",
+    "build:lib": "babel --no-babelrc --presets=es2015,react,stage-2 src --out-dir lib",
     "build:umd": "cross-env NODE_ENV=development webpack src/index.js dist/redux-spy.js",
     "build:umd:min": "cross-env NODE_ENV=production webpack src/index.js dist/redux-spy.min.js",
     "clean": "rimraf dist lib",

--- a/src/Spy.js
+++ b/src/Spy.js
@@ -1,7 +1,7 @@
-import { Component } from 'react'
+import React from 'react'
 import { connect } from 'react-redux'
 
-class Spy extends Component {
+class Spy extends React.Component {
   getProp(key) {
     return this.props[ key ]
   }

--- a/src/reduxSpy.js
+++ b/src/reduxSpy.js
@@ -1,9 +1,9 @@
-import React, { Component } from 'react'
+import React from 'react'
 import hoistStatics from 'hoist-non-react-statics'
 import Spy from './Spy'
 
 const reduxSpy = (mapStateToKeys = () => ({})) => WrappedComponent => {
-  class ReduxSpy extends Component {
+  class ReduxSpy extends React.Component {
     render() {
       return (
         <div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,11 @@ module.exports = {
   },
   module: {
     loaders: [
-      { test: /\.js$/, loaders: ['babel-loader'], exclude: /node_modules/ }
+      {
+        test: /\.js$/,
+        loader: 'babel-loader?presets[]=es2015&presets[]=react&presets[]=stage-2',
+        exclude: /node_modules/,
+      }
     ]
   },
   output: {


### PR DESCRIPTION
Hi there, I've gone ahead and made a pull request for #1. I've had to make more changes than I would've liked, but as far as I know it is not possible to have a second `.babelrc` file and then point the babel cli to it.

A summary of what I've done:

- modify `.babelrc` to not transpile modules
- add a `build:es6` script which uses the modified `.babelrc`, also added this task to the `build` script
- modify `build:lib` script to not use `.babelrc`, and instead specify presets on the cli directly
- modified `webpack.config.js` to specify presets on the loader, since the `.babelrc` no longer transpiles es6 modules, which makes webpack choke
- changed how `React.Component` is used - the reason I've had to do this, is because the `react` package does not explicitly export a `Component`, it exposes just a single namespace which holds a bunch of different things

Anyway, let me know your thoughts! :)